### PR TITLE
Docker compose support

### DIFF
--- a/backend/MangaMagnet.Api/Dockerfile
+++ b/backend/MangaMagnet.Api/Dockerfile
@@ -7,17 +7,18 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["MangaMagnet/MangaMagnet.csproj", "MangaMagnet/"]
-RUN dotnet restore "MangaMagnet/MangaMagnet.csproj"
+COPY ["MangaMagnet.Api/MangaMagnet.Api.csproj", "MangaMagnet.Api/"]
+COPY ["MangaMagnet.Core/MangaMagnet.Core.csproj", "MangaMagnet.Core/"]
+RUN dotnet restore "MangaMagnet.Api/MangaMagnet.Api.csproj"
 COPY . .
-WORKDIR "/src/MangaMagnet"
-RUN dotnet build "MangaMagnet.csproj" -c $BUILD_CONFIGURATION -o /app/build
+WORKDIR "/src/MangaMagnet.Api"
+RUN dotnet build "MangaMagnet.Api.csproj" --no-restore -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "MangaMagnet.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "MangaMagnet.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "MangaMagnet.dll"]
+ENTRYPOINT ["dotnet", "MangaMagnet.Api.dll"]

--- a/backend/MangaMagnet.Api/Program.cs
+++ b/backend/MangaMagnet.Api/Program.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Net;
 using System.Text.Json.Serialization;
 using Asp.Versioning;
@@ -150,7 +151,11 @@ using (var scope = app.Services.GetService<IServiceScopeFactory>()?.CreateScope(
 
         if (dbContext?.Database.GetDbConnection() is NpgsqlConnection npgsqlConnection)
         {
-            await npgsqlConnection.OpenAsync();
+	        if (npgsqlConnection.State != ConnectionState.Open)
+	        {
+		        await npgsqlConnection.OpenAsync();
+	        }
+
             try
             {
                 await npgsqlConnection.ReloadTypesAsync();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.1'
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: mangamagnet
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: mangamagnet
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mangamagnet -d mangamagnet"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - data:/var/lib/postgresql/data
+
+  backend:
+    image: mangamagnet-backend
+    build:
+      context: ./backend
+      dockerfile: MangaMagnet.Api/Dockerfile
+    ports:
+      - 43524:8080
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DOTNET_ConnectionStrings__PostgreSQLConnection: Host=postgres;Port=5432;Database=mangamagnet;Username=mangamagnet;Password=password
+      DOTNET_ConnectionStrings__QuartzPostgresSQLConnection: Host=postgres;Port=5432;Database=mangamagnet;Username=mangamagnet;Password=password;Search Path=quartz
+
+  frontend:
+    image: mangamagnet-frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - 43525:3000
+    depends_on:
+      - backend
+    environment:
+      API_BASE: http://backend:8080
+
+volumes:
+  data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+﻿node_modules
+.git
+.gitignore
+*.md
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-slim AS base
+WORKDIR /app
+
+FROM base AS base-pnpm
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+FROM base-pnpm AS prod-deps
+COPY package.json pnpm-lock.yaml ./
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
+
+FROM base-pnpm AS build
+COPY . /app
+ENV NEXT_TELEMETRY_DISABLED 1
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN pnpm run build
+
+FROM base
+COPY --from=build /app/public ./public
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+ENV PORT 3000
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    output: 'standalone',
     reactStrictMode: true,
     images: {
         remotePatterns: [{

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const config = {
+    matcher: ["/api/:path*"],
+};
+
+export function middleware(request: NextRequest) {
+    const API_BASE = process.env.API_BASE ?? 'http://localhost:5248'
+
+    return NextResponse.rewrite(
+        new URL(
+            `${API_BASE}${request.nextUrl.pathname}${request.nextUrl.search}`
+        ),
+        { request }
+    );
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,5 +1,8 @@
+import { OpenAPI } from '@/services/openapi'
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
+
+OpenAPI.BASE = '';
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />

--- a/frontend/src/services/openapi/core/OpenAPI.ts
+++ b/frontend/src/services/openapi/core/OpenAPI.ts
@@ -20,7 +20,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: 'http://localhost:5248',
+    BASE: '',
     VERSION: '1.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',

--- a/frontend/src/services/openapi/core/OpenAPI.ts
+++ b/frontend/src/services/openapi/core/OpenAPI.ts
@@ -20,7 +20,7 @@ export type OpenAPIConfig = {
 };
 
 export const OpenAPI: OpenAPIConfig = {
-    BASE: '',
+    BASE: 'http://localhost:5248',
     VERSION: '1.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/frontend/typings.d.ts
+++ b/frontend/typings.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+    readonly API_BASE: string
+}
+
+interface ImportMeta {
+    readonly env?: ImportMetaEnv
+}


### PR DESCRIPTION
Added Docker compose support:

```bash
docker compose build
docker compose up
```

## Backend
1. Fixed exception after applying migrations (`Database.Migrate()` opens the connection, so it was already open)
2. Fixed incorrect path in Dockerfile

## Frontend
1. Added Dockerfile
2. Fixed `next build` by setting JS-target to "es2015" since private fields are used in `src/services/openapi`
3. Added a middleware to proxy the API calls to the backend (so you don't have to open two ports)