### PR TITLE
fix(MangaDex): change the rating to nullable

### DIFF
--- a/backend/MangaMagnet.Core/Providers/MangaDex/MangaDexConverterService.cs
+++ b/backend/MangaMagnet.Core/Providers/MangaDex/MangaDexConverterService.cs
@@ -70,7 +70,7 @@ public class MangaDexConverterService
 		    attributes.Description.En,
 		    genres,
 		    tags,
-		    mangaDexStatistics.Rating.Average,
+		    mangaDexStatistics.Rating.Average ?? mangaDexStatistics.Rating.Bayesian ?? 0.0,
 		    GetCoverUrl(mangaDexData),
 		    GetAnilistId(mangaDexData),
 		    mangaDexData.Id,

--- a/backend/MangaMagnet.Core/Providers/MangaDex/Models/Statistics/MangaDexRating.cs
+++ b/backend/MangaMagnet.Core/Providers/MangaDex/Models/Statistics/MangaDexRating.cs
@@ -3,7 +3,7 @@
 namespace MangaMagnet.Core.Providers.MangaDex.Models.Statistics;
 
 public record MangaDexRating(
-    [property: JsonPropertyName("average")] double Average,
-    [property: JsonPropertyName("bayesian")] double Bayesian,
+    [property: JsonPropertyName("average")] double? Average,
+    [property: JsonPropertyName("bayesian")] double? Bayesian,
     [property: JsonPropertyName("distribution")] MangaDexRatingDistribution Distribution
 );


### PR DESCRIPTION
It is possible for the rating to be null, so we make it nullable.

As fallback we use Bayesian, when that is null we just show 0 as rating.