### PR TITLE
feat(TaskService): add description to tasks

### DIFF
--- a/backend/MangaMagnet.Api/Service/MetadataService.cs
+++ b/backend/MangaMagnet.Api/Service/MetadataService.cs
@@ -51,7 +51,7 @@ public class MetadataService(ILogger<MetadataService> logger, IMetadataFetcher m
 
 	public async Task<IEnumerable<MangaMetadataResponse>> UpdateAllMetadataAsync(CancellationToken cancellationToken = default)
 	{
-		using var progressTask = progressService.CreateTask("Refreshing Manga Metadata");
+		using var progressTask = progressService.CreateTask("Refreshing Metadata");
 
 		var metadata = await dbContext.MangaMetadata.ToListAsync(cancellationToken);
 
@@ -61,7 +61,7 @@ public class MetadataService(ILogger<MetadataService> logger, IMetadataFetcher m
 
 		foreach (var mangaMetadata in metadata)
 		{
-			progressTask.Name = $"Refresh {mangaMetadata.DisplayTitle}";
+			progressTask.Description = mangaMetadata.DisplayTitle;
 			updated.Add(await RefreshMetadataAsync(mangaMetadata.MangaDexId, cancellationToken));
 			progressTask.Increment();
 		}

--- a/backend/MangaMagnet.Core/Progress/Models/ProgressTask.cs
+++ b/backend/MangaMagnet.Core/Progress/Models/ProgressTask.cs
@@ -6,6 +6,7 @@ namespace MangaMagnet.Core.Progress.Models;
 public sealed class ProgressTask : INotifyPropertyChanged, IDisposable, IProgress<int>
 {
     private string _name = "New task";
+    private string? _description;
     private int _progress;
     private bool _isCompleted;
     private int? _total;
@@ -33,6 +34,15 @@ public sealed class ProgressTask : INotifyPropertyChanged, IDisposable, IProgres
         get => _name;
         set => SetField(ref _name, value);
     }
+
+	/// <summary>
+	/// Gets or sets the description of the task.
+	/// </summary>
+	public string? Description
+	{
+		get => _description;
+		set => SetField(ref _description, value);
+	}
 
     /// <summary>
     /// Gets or sets the progress of the task.

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -18,11 +18,18 @@ export const TaskList = () => {
                     <div className="flex flex-col space-y-2">
                         {shownTasks.map(i => (
                             <div key={i.id}>
-                                <div className="flex mb-1 text-xs font-semibold text-gray-400">
+                                <div className="flex text-xs font-semibold text-gray-400">
                                     <div className="flex-1">{i.name}</div>
                                     <div>{i.progress}%</div>
                                 </div>
-                                <div className="h-[6px] bg-slate-400" style={{ width: `${i.progress}%`, transition: 'width .25s' }} role="progressbar" aria-valuenow={i.progress} aria-valuemin={0} aria-valuemax={1}></div>
+                                {i.description && <div title={i.description} className="text-gray-500 text-xs whitespace-nowrap overflow-ellipsis overflow-hidden">{i.description}</div>}
+                                {i.indeterminate ? (
+                                    <div className="relative h-[6px] mt-2 overflow-hidden">
+                                        <div className="absolute h-[6px] bg-slate-400 animate-indeterminate" style={{ width: `${Math.max(i.progress, 20)}%`, transition: 'width .25s' }} role="progressbar"></div>
+                                    </div>
+                                ) : (
+                                    <div className="h-[6px] mt-2 bg-slate-400" style={{ width: `${i.progress}%`, transition: 'width .25s' }} role="progressbar" aria-valuenow={i.progress} aria-valuemin={0} aria-valuemax={1}></div>
+                                )}
                             </div>
                         ))}
                     </div>

--- a/frontend/src/services/openapi/models/ProgressTask.ts
+++ b/frontend/src/services/openapi/models/ProgressTask.ts
@@ -12,6 +12,10 @@ export type ProgressTask = {
      */
     name: string;
     /**
+     * Gets or sets the description of the task.
+     */
+    description?: string | null;
+    /**
      * Gets or sets the progress of the task.
      */
     progress: number;
@@ -19,5 +23,11 @@ export type ProgressTask = {
      * `true` if the task is completed, `false` otherwise.
      */
     isCompleted: boolean;
+    /**
+     * `true` if the task is indeterminate, `false` otherwise.
+     */
+    indeterminate: boolean;
+    total?: number | null;
+    current: number;
 };
 

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -70,3 +70,16 @@ body {
 .rotate-180 {
 	transform: rotate(180deg);
 }
+
+.animate-indeterminate {
+	animation: indeterminate 3s infinite cubic-bezier(0.39, 0.575, 0.565, 1)
+}
+
+@keyframes indeterminate {
+	0% {
+		left: -100%;
+	}
+	100% {
+		left: 100%;
+	}
+}


### PR DESCRIPTION
Instead of changing the name for each manga, I've added a description to the tasks that shows which manga is being updated. I've also changed it so that the description can only be on one line (hover over it to see the full description) so the task list doesn't jump around (less distracting).

https://github.com/SimplyMedia/MangaMagnet/assets/2109929/3d91a273-c6ae-4398-b130-009405c5a6dc


I've also implemented `Indeterminate`, which currently isn't being used. In the future we can use this for long tasks where we don't know the progress percentage (e.g. long running HTTP request):

https://github.com/SimplyMedia/MangaMagnet/assets/2109929/1984b42b-2f6c-40af-8c9a-bfbcd92428ab